### PR TITLE
sql removed because mysql_query deprecated in php 5.5 and removed in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 7. Authentication Bypass/Insecure Permissions
 8. Cross-Site Scripting(XSS)
 9. Cross Site Request Forgery(CSRF)
-10. SQL Injection
 
 ##1) Remote File Inclusion
 ####Affected PHP Functions


### PR DESCRIPTION
…php 7.0
